### PR TITLE
CI: change deprecated ubuntu runner image

### DIFF
--- a/.github/workflows/ci-moodle3.10.yml
+++ b/.github/workflows/ci-moodle3.10.yml
@@ -7,7 +7,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-moodle3.11.yml
+++ b/.github/workflows/ci-moodle3.11.yml
@@ -7,7 +7,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-moodle3.4.yml
+++ b/.github/workflows/ci-moodle3.4.yml
@@ -7,7 +7,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-moodle3.5.yml
+++ b/.github/workflows/ci-moodle3.5.yml
@@ -7,7 +7,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-moodle3.6.yml
+++ b/.github/workflows/ci-moodle3.6.yml
@@ -7,7 +7,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-moodle3.7.yml
+++ b/.github/workflows/ci-moodle3.7.yml
@@ -7,7 +7,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-moodle3.8.yml
+++ b/.github/workflows/ci-moodle3.8.yml
@@ -7,7 +7,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-moodle3.9.yml
+++ b/.github/workflows/ci-moodle3.9.yml
@@ -7,7 +7,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
ubuntu-18.04 image is deprecated and needs to be changed see https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/